### PR TITLE
App Tile Support

### DIFF
--- a/Marconio.xcodeproj/project.pbxproj
+++ b/Marconio.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		72E1795227A39561009A20ED /* LaceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 72E1795127A39561009A20ED /* LaceKit */; };
 		72E1795627A3AC50009A20ED /* Mixtape+Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E1795527A3AC50009A20ED /* Mixtape+Icons.swift */; };
 		72E1795727A3AC50009A20ED /* Mixtape+Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72E1795527A3AC50009A20ED /* Mixtape+Icons.swift */; };
+		72FD675027AC972000611387 /* AppTileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728797F727A978BD00FE38B3 /* AppTileClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -365,6 +366,7 @@
 				727AD85127A6D75100F224CF /* MarconioCommands.swift in Sources */,
 				725B5DF227A4436300459EE3 /* PlaybackCore.swift in Sources */,
 				727AD85D27A6DC8700F224CF /* ChannelsView.swift in Sources */,
+				72FD675027AC972000611387 /* AppTileClient.swift in Sources */,
 				727CC0F827A76F0B00CABE53 /* MarconioVersionInformation.swift in Sources */,
 				72A6B3E427A5FCD2002AF923 /* URL+Opener.swift in Sources */,
 				72E1793C27A2E48D009A20ED /* MarconioApp.swift in Sources */,

--- a/Marconio.xcodeproj/project.pbxproj
+++ b/Marconio.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		727AD85E27A6DC8700F224CF /* ChannelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727AD85C27A6DC8700F224CF /* ChannelsView.swift */; };
 		727CC0F827A76F0B00CABE53 /* MarconioVersionInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727CC0F727A76F0B00CABE53 /* MarconioVersionInformation.swift */; };
 		727CC0F927A76F0B00CABE53 /* MarconioVersionInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727CC0F727A76F0B00CABE53 /* MarconioVersionInformation.swift */; };
+		728797F927A978BD00FE38B3 /* AppTileClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728797F727A978BD00FE38B3 /* AppTileClient.swift */; };
 		72A6B3E127A5F42A002AF923 /* DonationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A6B3E027A5F42A002AF923 /* DonationView.swift */; };
 		72A6B3E227A5F42D002AF923 /* DonationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A6B3E027A5F42A002AF923 /* DonationView.swift */; };
 		72A6B3E427A5FCD2002AF923 /* URL+Opener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72A6B3E327A5FCD2002AF923 /* URL+Opener.swift */; };
@@ -55,6 +56,7 @@
 		727AD85327A6D85F00F224CF /* MarconioAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioAppDelegate.swift; sourceTree = "<group>"; };
 		727AD85C27A6DC8700F224CF /* ChannelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelsView.swift; sourceTree = "<group>"; };
 		727CC0F727A76F0B00CABE53 /* MarconioVersionInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MarconioVersionInformation.swift; sourceTree = "<group>"; };
+		728797F727A978BD00FE38B3 /* AppTileClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTileClient.swift; sourceTree = "<group>"; };
 		72A6B3E027A5F42A002AF923 /* DonationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DonationView.swift; sourceTree = "<group>"; };
 		72A6B3E327A5FCD2002AF923 /* URL+Opener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Opener.swift"; sourceTree = "<group>"; };
 		72A6B3E727A5FEDE002AF923 /* NowPlayingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingView.swift; sourceTree = "<group>"; };
@@ -116,6 +118,14 @@
 				727AD85C27A6DC8700F224CF /* ChannelsView.swift */,
 			);
 			path = Channels;
+			sourceTree = "<group>";
+		};
+		728797F627A978A400FE38B3 /* App Tile */ = {
+			isa = PBXGroup;
+			children = (
+				728797F727A978BD00FE38B3 /* AppTileClient.swift */,
+			);
+			path = "App Tile";
 			sourceTree = "<group>";
 		};
 		72A6B3DF27A5F420002AF923 /* Donation */ = {
@@ -185,6 +195,7 @@
 		72E1792B27A2E48C009A20ED /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				728797F627A978A400FE38B3 /* App Tile */,
 				72B56A1627A715A400C8FC8B /* Models */,
 				72B56A1227A70EE400C8FC8B /* External Commands */,
 				727AD85827A6DC5F00F224CF /* Channels */,
@@ -367,6 +378,7 @@
 				72B56A1527A70EF000C8FC8B /* ExternalCommandsClient.swift in Sources */,
 				727AD85727A6D9EC00F224CF /* NowPlayingView.swift in Sources */,
 				727AD85627A6D86700F224CF /* MarconioAppDelegate.swift in Sources */,
+				728797F927A978BD00FE38B3 /* AppTileClient.swift in Sources */,
 				727AD85227A6D75100F224CF /* MarconioCommands.swift in Sources */,
 				72E1795727A3AC50009A20ED /* Mixtape+Icons.swift in Sources */,
 				72D5928D27A5A21E00D3CE52 /* AppView.swift in Sources */,

--- a/Shared/App Tile/AppTileClient.swift
+++ b/Shared/App Tile/AppTileClient.swift
@@ -22,6 +22,8 @@ struct AppTileClient {
 
 extension AppTileClient {
     static var live: Self {
+        // TODO: This doesn't feel right to pull in the stateful call of the dock menu
+        // What's the better way to accomplish this?
         let menu = NSApp.delegate?.applicationDockMenu?(NSApp)
 
         return Self(
@@ -33,18 +35,5 @@ extension AppTileClient {
                 menu?.addItem(playable)
             }
         )
-    }
-}
-
-struct DockTileView: View {
-    var playable: MediaPlayable
-
-    var body: some View {
-        VStack(alignment: .leading) {
-            Text(playable.title).bold()
-            if let subtitle = playable.subtitle {
-                Text(subtitle).font(.subheadline)
-            }
-        }
     }
 }

--- a/Shared/App Tile/AppTileClient.swift
+++ b/Shared/App Tile/AppTileClient.swift
@@ -13,21 +13,19 @@ import AppKit
 import UIKit
 #endif
 
-import SwiftUI
-
-
 struct AppTileClient {
-    var updateDockTile: (MediaPlayable) -> Void
+    var updateAppTile: (MediaPlayable) -> Void
 }
 
 extension AppTileClient {
     static var live: Self {
         // TODO: This doesn't feel right to pull in the stateful call of the dock menu
         // What's the better way to accomplish this?
+        #if os(macOS)
         let menu = NSApp.delegate?.applicationDockMenu?(NSApp)
 
         return Self(
-            updateDockTile: { playable in
+            updateAppTile: { playable in
                 menu?.removeAllItems()
                 let heading = NSMenuItem(title: "Now Playing", action: nil, keyEquivalent: "")
                 let playable = NSMenuItem(title: "NTS - \(playable.title)", action: nil, keyEquivalent: "")
@@ -35,5 +33,10 @@ extension AppTileClient {
                 menu?.addItem(playable)
             }
         )
+        #else
+        return Self(
+            updateAppTile: { _ in }
+        )
+        #endif
     }
 }

--- a/Shared/App Tile/AppTileClient.swift
+++ b/Shared/App Tile/AppTileClient.swift
@@ -1,0 +1,50 @@
+//
+//  AppTileCore.swift
+//  Marconio
+//
+//  Created by Brian Michel on 2/1/22.
+//
+
+import ComposableArchitecture
+import Foundation
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+import SwiftUI
+
+
+struct AppTileClient {
+    var updateDockTile: (MediaPlayable) -> Void
+}
+
+extension AppTileClient {
+    static var live: Self {
+        let menu = NSApp.delegate?.applicationDockMenu?(NSApp)
+
+        return Self(
+            updateDockTile: { playable in
+                menu?.removeAllItems()
+                let heading = NSMenuItem(title: "Now Playing", action: nil, keyEquivalent: "")
+                let playable = NSMenuItem(title: "NTS - \(playable.title)", action: nil, keyEquivalent: "")
+                menu?.addItem(heading)
+                menu?.addItem(playable)
+            }
+        )
+    }
+}
+
+struct DockTileView: View {
+    var playable: MediaPlayable
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(playable.title).bold()
+            if let subtitle = playable.subtitle {
+                Text(subtitle).font(.subheadline)
+            }
+        }
+    }
+}

--- a/Shared/Main/Playback/PlaybackCore.swift
+++ b/Shared/Main/Playback/PlaybackCore.swift
@@ -44,6 +44,7 @@ struct PlaybackEnvironment {
     var mainQueue: DispatchQueue = .main
     var infoCenter = MPNowPlayingInfoCenter.default()
     var externalCommandsClient: ExternalCommandsClient = .live
+    var appTileClient: AppTileClient = .live
 }
 
 let playbackReducer = Reducer<PlaybackState, PlaybackAction, PlaybackEnvironment>.combine(
@@ -56,6 +57,7 @@ let playbackReducer = Reducer<PlaybackState, PlaybackAction, PlaybackEnvironment
             PlaybackEnvironment.player.play()
             state.playerState = .playing
             environment.infoCenter.playbackState = .playing
+            environment.appTileClient.updateDockTile(playable)
 
             state.currentlyPlaying = playable
             return .merge(

--- a/Shared/Main/Playback/PlaybackCore.swift
+++ b/Shared/Main/Playback/PlaybackCore.swift
@@ -57,7 +57,7 @@ let playbackReducer = Reducer<PlaybackState, PlaybackAction, PlaybackEnvironment
             PlaybackEnvironment.player.play()
             state.playerState = .playing
             environment.infoCenter.playbackState = .playing
-            environment.appTileClient.updateDockTile(playable)
+            environment.appTileClient.updateAppTile(playable)
 
             state.currentlyPlaying = playable
             return .merge(

--- a/Shared/MarconioApp.swift
+++ b/Shared/MarconioApp.swift
@@ -16,6 +16,10 @@ struct MarconioApp: App {
     @NSApplicationDelegateAdaptor(MarconioAppDelegate.self) var appDelegate
     #endif
 
+    init() {
+        print("does this get logged?")
+    }
+
     var body: some Scene {
         WindowGroup {
             AppView(

--- a/macOS/MarconioAppDelegate.swift
+++ b/macOS/MarconioAppDelegate.swift
@@ -11,11 +11,17 @@ import AppKit
 /// Create an AppDelegate to terminate the application when the last window is closed.
 /// This is a hack around SwiftUI for the time being...
 class MarconioAppDelegate: NSObject, NSApplicationDelegate {
+    private let dockMenu = NSMenu()
+    
     func applicationWillFinishLaunching(_ notification: Notification) {
         NSWindow.allowsAutomaticWindowTabbing = false
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         return true
+    }
+
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        return dockMenu
     }
 }


### PR DESCRIPTION
Add the beginning of "App Tile" support to the project.

Right now, this only supports behaviors within macOS of adding an additional menu to the context menu when right-clicking the dock tile.

In the future, this can be reused to update shortcut items within iOS I believe, or with some light refactoring it might be possible.