### PR TITLE
Add Persistence

### DIFF
--- a/AppCore/Package.swift
+++ b/AppCore/Package.swift
@@ -20,12 +20,16 @@ let package = Package(
         .library(
             name: "Models",
             targets: ["Models"]),
+        .library(
+            name: "DatabaseClient",
+            targets: ["DatabaseClient"])
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/pointfreeco/swift-composable-architecture", from: "0.33.1"),
         .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.1"),
+        .package(url: "https://github.com/groue/GRDB.swift.git", from: "5.21.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -48,6 +52,12 @@ let package = Package(
                     .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                     "Models"
                 ]
-        )
+        ),
+        .target(name: "DatabaseClient",
+                dependencies: [
+                    .product(name: "GRDB", package: "GRDB.swift"),
+                    "Models"
+                ]
+               )
     ]
 )

--- a/AppCore/Sources/DatabaseClient/Client.swift
+++ b/AppCore/Sources/DatabaseClient/Client.swift
@@ -20,6 +20,7 @@ public struct DatabaseClient {
     public var fetchAllChannels: () -> Effect<Action, DatabaseClient.Error>
     public var fetchAllMixtapes: () -> Effect<Action, DatabaseClient.Error>
     public var startRealtimeUpdates: () -> Effect<Action, DatabaseClient.Error>
+    public var stopRealtimeUpdates: () -> Effect<Void, DatabaseClient.Error>
 
     public enum Action: Equatable {
         case didFetchAllMixtapes([Mixtape])
@@ -65,7 +66,7 @@ public struct DatabaseClient {
         return migrator
     }
 
-    init(dbWriter: DatabaseWriter, writeChannel: @escaping (Channel) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeChannels: @escaping ([Channel]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtape: @escaping (Mixtape) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtapes: @escaping ([Mixtape]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllChannels: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllMixtapes: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, startRealtimeUpdates: @escaping () -> Effect<Action, DatabaseClient.Error>) {
+    init(dbWriter: DatabaseWriter, writeChannel: @escaping (Channel) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeChannels: @escaping ([Channel]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtape: @escaping (Mixtape) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtapes: @escaping ([Mixtape]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllChannels: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllMixtapes: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, startRealtimeUpdates: @escaping () -> Effect<Action, DatabaseClient.Error>, stopRealtimeUpdates: @escaping () -> Effect<Void, DatabaseClient.Error>) {
         self.dbWriter = dbWriter
         self.writeChannel = writeChannel
         self.writeChannels = writeChannels
@@ -74,6 +75,7 @@ public struct DatabaseClient {
         self.fetchAllChannels = fetchAllChannels
         self.fetchAllMixtapes = fetchAllMixtapes
         self.startRealtimeUpdates = startRealtimeUpdates
+        self.stopRealtimeUpdates = stopRealtimeUpdates
 
         try? migrator.migrate(dbWriter)
     }

--- a/AppCore/Sources/DatabaseClient/Client.swift
+++ b/AppCore/Sources/DatabaseClient/Client.swift
@@ -1,0 +1,82 @@
+//
+//  Client.swift
+//  
+//
+//  Created by Brian Michel on 2/6/22.
+//
+
+import Foundation
+import GRDB
+import Models
+
+public struct DatabaseClient {
+    private let dbWriter: DatabaseWriter
+
+    private var migrator: DatabaseMigrator {
+        var migrator = DatabaseMigrator()
+
+        #if DEBUG
+        // Speed things up when working in DEBUG mode
+        migrator.eraseDatabaseOnSchemaChange = true
+        #endif
+
+        migrator.registerMigration("createChannels") { db in
+            try db.create(table: "channel", body: { t in
+                t.column("channelName", .text).notNull().primaryKey()
+                t.column("now", .blob).notNull()
+                t.column("next", .blob).notNull()
+            })
+        }
+
+        migrator.registerMigration("createMixtapes") { db in
+            try db.create(table: "mixtape", body: { t in
+                t.column("mixtapeAlias", .text).notNull().primaryKey()
+                t.column("title", .text).notNull()
+                t.column("subtitle", .text).notNull()
+                t.column("description", .text).notNull()
+                t.column("descriptionHtml", .text).notNull()
+                t.column("audioStreamEndpoint", .text).notNull()
+                t.column("media", .blob).notNull()
+                t.column("nowPlayingTopic", .text).notNull()
+                t.column("links", .blob).notNull()
+            })
+        }
+
+        return migrator
+    }
+
+    init(_ dbWriter: DatabaseWriter) throws {
+        self.dbWriter = dbWriter
+        try migrator.migrate(dbWriter)
+    }
+}
+
+public extension DatabaseClient {
+    func writeChannels(_ channels: [Channel]) throws {
+        try dbWriter.write { db in
+            try channels.forEach { channel in
+                try channel.save(db)
+            }
+        }
+    }
+
+    func writeChannel(_ channel: Channel) throws {
+        try dbWriter.write { db in
+            try channel.save(db)
+        }
+    }
+
+    func writeMixtapes(_ mixtapes: [Mixtape]) throws {
+        try dbWriter.write { db in
+            try mixtapes.forEach { mixtape in
+                try mixtape.save(db)
+            }
+        }
+    }
+
+    func writeMixtape(_ mixtape: Mixtape) throws {
+        try dbWriter.write { db in
+            try mixtape.save(db)
+        }
+    }
+}

--- a/AppCore/Sources/DatabaseClient/Client.swift
+++ b/AppCore/Sources/DatabaseClient/Client.swift
@@ -19,10 +19,12 @@ public struct DatabaseClient {
     public var writeMixtapes: ([Mixtape]) -> Effect<Action, DatabaseClient.Error>
     public var fetchAllChannels: () -> Effect<Action, DatabaseClient.Error>
     public var fetchAllMixtapes: () -> Effect<Action, DatabaseClient.Error>
+    public var startRealtimeUpdates: () -> Effect<Action, DatabaseClient.Error>
 
     public enum Action: Equatable {
         case didFetchAllMixtapes([Mixtape])
         case didFetchAllChannels([Channel])
+        case realTimeUpdate([Channel], [Mixtape])
     }
 
     public enum Error: Swift.Error, Equatable {
@@ -63,7 +65,7 @@ public struct DatabaseClient {
         return migrator
     }
 
-    init(dbWriter: DatabaseWriter, writeChannel: @escaping (Channel) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeChannels: @escaping ([Channel]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtape: @escaping (Mixtape) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtapes: @escaping ([Mixtape]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllChannels: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllMixtapes: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>) {
+    init(dbWriter: DatabaseWriter, writeChannel: @escaping (Channel) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeChannels: @escaping ([Channel]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtape: @escaping (Mixtape) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, writeMixtapes: @escaping ([Mixtape]) -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllChannels: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, fetchAllMixtapes: @escaping () -> Effect<DatabaseClient.Action, DatabaseClient.Error>, startRealtimeUpdates: @escaping () -> Effect<Action, DatabaseClient.Error>) {
         self.dbWriter = dbWriter
         self.writeChannel = writeChannel
         self.writeChannels = writeChannels
@@ -71,6 +73,7 @@ public struct DatabaseClient {
         self.writeMixtapes = writeMixtapes
         self.fetchAllChannels = fetchAllChannels
         self.fetchAllMixtapes = fetchAllMixtapes
+        self.startRealtimeUpdates = startRealtimeUpdates
 
         try? migrator.migrate(dbWriter)
     }

--- a/AppCore/Sources/DatabaseClient/Live.swift
+++ b/AppCore/Sources/DatabaseClient/Live.swift
@@ -1,0 +1,35 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brian Michel on 2/6/22.
+//
+
+import Foundation
+import GRDB
+
+public enum DatabaseClientError: Error {
+    case unableToCreateContainerURL
+}
+
+public extension DatabaseClient {
+    static var live: Self {
+        do {
+            let fileManager = FileManager()
+            let folderURL = try fileManager
+                .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+                .appendingPathComponent("db", isDirectory: true)
+
+            try fileManager.createDirectory(at: folderURL, withIntermediateDirectories: true, attributes: nil)
+
+            let dbURL = folderURL.appendingPathComponent("db.sqlite")
+            let dbPool = try DatabasePool(path: dbURL.path)
+
+            let client = try DatabaseClient(dbPool)
+
+            return client
+        } catch {
+            fatalError("Unable to setup database client due to error: \(error)")
+        }
+    }
+}

--- a/AppCore/Sources/DatabaseClient/Live.swift
+++ b/AppCore/Sources/DatabaseClient/Live.swift
@@ -30,11 +30,11 @@ public extension DatabaseClient {
                 AnyPublisher<[Mixtape], DatabasePublishers.Value<[Mixtape]>.Failure>
             > {
                 let allMixtapes = ValueObservation.tracking { db in
-                    try Mixtape.order(Column("title").asc).fetchAll(db)
+                    try Mixtape.allMixtapes(db: db)
                 }.publisher(in: writer, scheduling: .immediate)
                     .eraseToAnyPublisher()
                 let allChannels = ValueObservation.tracking { db in
-                    try Channel.order(Column("channelName").asc).fetchAll(db)
+                    try Channel.allChannels(db: db)
                 }.publisher(in: writer, scheduling: .immediate)
                     .eraseToAnyPublisher()
 
@@ -109,9 +109,7 @@ public extension DatabaseClient {
                     .run { subscriber in
                         do {
                             try writer.write { db in
-                                let channels = try Channel
-                                    .order(Column("channelName").asc)
-                                    .fetchAll(db)
+                                let channels = try Channel.allChannels(db: db)
 
                                 subscriber.send(.didFetchAllChannels(channels))
                             }
@@ -126,9 +124,7 @@ public extension DatabaseClient {
                     .run { subscriber in
                         do {
                             try writer.write { db in
-                                let mixtapes = try Mixtape
-                                    .order(Column("mixtapeAlias").asc)
-                                    .fetchAll(db)
+                                let mixtapes = try Mixtape.allMixtapes(db: db)
 
                                 subscriber.send(.didFetchAllMixtapes(mixtapes))
                             }

--- a/AppCore/Sources/DatabaseClient/Models.swift
+++ b/AppCore/Sources/DatabaseClient/Models.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brian Michel on 2/6/22.
+//
+
+import Foundation
+import Models
+import GRDB
+
+extension Mixtape: PersistableRecord, FetchableRecord {}
+
+extension Channel: PersistableRecord, FetchableRecord {}

--- a/AppCore/Sources/DatabaseClient/Models.swift
+++ b/AppCore/Sources/DatabaseClient/Models.swift
@@ -10,5 +10,4 @@ import Models
 import GRDB
 
 extension Mixtape: PersistableRecord, FetchableRecord {}
-
 extension Channel: PersistableRecord, FetchableRecord {}

--- a/AppCore/Sources/DatabaseClient/Models.swift
+++ b/AppCore/Sources/DatabaseClient/Models.swift
@@ -9,5 +9,18 @@ import Foundation
 import Models
 import GRDB
 
-extension Mixtape: PersistableRecord, FetchableRecord {}
-extension Channel: PersistableRecord, FetchableRecord {}
+extension Mixtape: PersistableRecord, FetchableRecord {
+    static func allMixtapes(db: Database) throws -> [Mixtape] {
+        return try Mixtape
+            .order(Column("mixtapeAlias").asc)
+            .fetchAll(db)
+    }
+}
+extension Channel: PersistableRecord, FetchableRecord {
+    static func allChannels(db: Database) throws -> [Channel] {
+        return try Channel
+            .order(Column("channelName").asc)
+            .fetchAll(db)
+    }
+
+}

--- a/Marconio.xcodeproj/project.pbxproj
+++ b/Marconio.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		72135D0327B0B04700ADF1D3 /* DatabaseClient in Frameworks */ = {isa = PBXBuildFile; productRef = 72135D0227B0B04700ADF1D3 /* DatabaseClient */; };
+		72135D0527B0B04D00ADF1D3 /* DatabaseClient in Frameworks */ = {isa = PBXBuildFile; productRef = 72135D0427B0B04D00ADF1D3 /* DatabaseClient */; };
 		721A6E1627AF2FF8006FF195 /* LaceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 721A6E1527AF2FF8006FF195 /* LaceKit */; };
 		721A6E1827AF2FF8006FF195 /* Models in Frameworks */ = {isa = PBXBuildFile; productRef = 721A6E1727AF2FF8006FF195 /* Models */; };
 		721A6E1A27AF2FF8006FF195 /* UserActivityClient in Frameworks */ = {isa = PBXBuildFile; productRef = 721A6E1927AF2FF8006FF195 /* UserActivityClient */; };
@@ -105,6 +107,7 @@
 				721A6E1827AF2FF8006FF195 /* Models in Frameworks */,
 				721A6E1A27AF2FF8006FF195 /* UserActivityClient in Frameworks */,
 				721A6E1627AF2FF8006FF195 /* LaceKit in Frameworks */,
+				72135D0527B0B04D00ADF1D3 /* DatabaseClient in Frameworks */,
 				72D5928227A591A100D3CE52 /* ComposableArchitecture in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -115,6 +118,7 @@
 			files = (
 				721A6E1C27AF2FFF006FF195 /* LaceKit in Frameworks */,
 				72EB165F27ADB97100B7952B /* Sparkle in Frameworks */,
+				72135D0327B0B04700ADF1D3 /* DatabaseClient in Frameworks */,
 				721A6E1E27AF2FFF006FF195 /* Models in Frameworks */,
 				721A6E2027AF2FFF006FF195 /* UserActivityClient in Frameworks */,
 				72D5928027A5918A00D3CE52 /* ComposableArchitecture in Frameworks */,
@@ -327,6 +331,7 @@
 				721A6E1527AF2FF8006FF195 /* LaceKit */,
 				721A6E1727AF2FF8006FF195 /* Models */,
 				721A6E1927AF2FF8006FF195 /* UserActivityClient */,
+				72135D0427B0B04D00ADF1D3 /* DatabaseClient */,
 			);
 			productName = "Lace (iOS)";
 			productReference = 72E1793327A2E48D009A20ED /* Marconio.app */;
@@ -351,6 +356,7 @@
 				721A6E1B27AF2FFF006FF195 /* LaceKit */,
 				721A6E1D27AF2FFF006FF195 /* Models */,
 				721A6E1F27AF2FFF006FF195 /* UserActivityClient */,
+				72135D0227B0B04700ADF1D3 /* DatabaseClient */,
 			);
 			productName = "Lace (macOS)";
 			productReference = 72E1793927A2E48D009A20ED /* Marconio.app */;
@@ -770,6 +776,14 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		72135D0227B0B04700ADF1D3 /* DatabaseClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DatabaseClient;
+		};
+		72135D0427B0B04D00ADF1D3 /* DatabaseClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = DatabaseClient;
+		};
 		721A6E1527AF2FF8006FF195 /* LaceKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = LaceKit;

--- a/Marconio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Marconio.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "GRDB",
+        "repositoryURL": "https://github.com/groue/GRDB.swift.git",
+        "state": {
+          "branch": null,
+          "revision": "d40474d2b78fe530d0cf1216c46fd1fc5e30e539",
+          "version": "5.21.0"
+        }
+      },
+      {
         "package": "Sparkle",
         "repositoryURL": "https://github.com/sparkle-project/Sparkle",
         "state": {

--- a/Shared/Channels/ChannelsView.swift
+++ b/Shared/Channels/ChannelsView.swift
@@ -149,7 +149,8 @@ struct ChannelsView_Previews: PreviewProvider {
                     mainQueue: .main,
                     uuid: UUID.init,
                     api: LiveAPI(),
-                    appDelegate: .init()
+                    appDelegate: .init(),
+                    dbClient: .live
                 )
             )
         )

--- a/Shared/Main/AppCore.swift
+++ b/Shared/Main/AppCore.swift
@@ -8,7 +8,7 @@ import ComposableArchitecture
 import Foundation
 import LaceKit
 import Models
-
+import DatabaseClient
 
 struct AppState: Equatable {
     var channels: [Channel] = []
@@ -32,6 +32,7 @@ struct AppEnvironment {
     var uuid: () -> UUID
     var api: NTSAPI
     var appDelegate: AppDelegateEnvironment
+    var dbClient: DatabaseClient
 }
 
 let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
@@ -63,6 +64,7 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
                 .catchToEffect(AppAction.channelsResponse)
         case let .channelsResponse(.success(channels)):
             state.channels = channels.results
+            try? environment.dbClient.writeChannels(channels.results)
             return .none
         case let .channelsResponse(.failure(error)):
             // Do something with the error here
@@ -74,6 +76,7 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
                 .catchToEffect(AppAction.mixtapesResponse)
         case let .mixtapesResponse(.success(mixtapes)):
             state.mixtapes = mixtapes.results
+            try? environment.dbClient.writeMixtapes(mixtapes.results)
             return .none
         case let .mixtapesResponse(.failure(error)):
             // Do something with the error here

--- a/Shared/Main/AppView.swift
+++ b/Shared/Main/AppView.swift
@@ -59,7 +59,8 @@ struct AppView_Previews: PreviewProvider {
                     mainQueue: .main,
                     uuid: UUID.init,
                     api: LiveAPI(),
-                    appDelegate: .init()
+                    appDelegate: .init(),
+                    dbClient: .live
                 )
             )
         )

--- a/macOS/MarconioMacAppDelegate.swift
+++ b/macOS/MarconioMacAppDelegate.swift
@@ -26,7 +26,8 @@ final class MarconioMacAppDelegate: NSObject, NSApplicationDelegate {
             mainQueue: .main,
             uuid: UUID.init,
             api: LiveAPI(),
-            appDelegate: .init()
+            appDelegate: .init(),
+            dbClient: .live
         )
     )
 


### PR DESCRIPTION
This PR adds persistence to store the Channels and Mixtapes in a durable form on disk. This can help the app be more resilient during network blips, but also sets the stage for moving this into app group container so that data can be shared with widgets and things like that in the future.