### PR TITLE
Add New Floating Mini Player

### DIFF
--- a/AppCore/Sources/AppCore/AppCore.swift
+++ b/AppCore/Sources/AppCore/AppCore.swift
@@ -17,6 +17,7 @@ public struct AppState: Equatable {
     public var mixtapes: [Mixtape] = []
     public var playback: PlaybackState = .init()
     public var appDelegateState: AppDelegateState
+    public var selectedPlayable: MediaPlayable?
 
     public init(channels: [Channel] = [], mixtapes: [Mixtape] = [], playback: PlaybackState = .init(), appDelegateState: AppDelegateState) {
         self.channels = channels
@@ -33,6 +34,7 @@ public enum AppAction: Equatable {
     case channelsResponse(Result<LiveBroadcastsResponse, RunnerError>)
     case loadMixtapes
     case mixtapesResponse(Result<MixtapesResponse, RunnerError>)
+    case selectPlayable(MediaPlayable?)
     case playback(PlaybackAction)
     case appDelegate(AppDelegateAction)
     case db(Result<DatabaseClient.Action, DatabaseClient.Error>)
@@ -130,6 +132,9 @@ public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
         case .db(.success(.didFetchAllMixtapes(_))):
             return .none
         case .db(.success(.didFetchAllChannels(_))):
+            return .none
+        case let .selectPlayable(playable):
+            state.selectedPlayable = playable
             return .none
         }
     }

--- a/AppCore/Sources/AppCore/AppCore.swift
+++ b/AppCore/Sources/AppCore/AppCore.swift
@@ -17,7 +17,6 @@ public struct AppState: Equatable {
     public var mixtapes: [Mixtape] = []
     public var playback: PlaybackState = .init()
     public var appDelegateState: AppDelegateState
-    public var selectedPlayable: MediaPlayable?
 
     public init(channels: [Channel] = [], mixtapes: [Mixtape] = [], playback: PlaybackState = .init(), appDelegateState: AppDelegateState) {
         self.channels = channels
@@ -34,7 +33,6 @@ public enum AppAction: Equatable {
     case channelsResponse(Result<LiveBroadcastsResponse, RunnerError>)
     case loadMixtapes
     case mixtapesResponse(Result<MixtapesResponse, RunnerError>)
-    case selectPlayable(MediaPlayable?)
     case playback(PlaybackAction)
     case appDelegate(AppDelegateAction)
     case db(Result<DatabaseClient.Action, DatabaseClient.Error>)
@@ -132,9 +130,6 @@ public let appReducer = Reducer<AppState, AppAction, AppEnvironment>.combine(
         case .db(.success(.didFetchAllMixtapes(_))):
             return .none
         case .db(.success(.didFetchAllChannels(_))):
-            return .none
-        case let .selectPlayable(playable):
-            state.selectedPlayable = playable
             return .none
         }
     }

--- a/AppCore/Sources/Models/Either.swift
+++ b/AppCore/Sources/Models/Either.swift
@@ -1,0 +1,13 @@
+//
+//  Either.swift
+//  
+//
+//  Created by Brian Michel on 2/13/22.
+//
+
+import Foundation
+
+public enum Either<Left: Equatable, Right: Equatable>: Equatable {
+    case left(Left)
+    case right(Right)
+}

--- a/AppCore/Sources/Models/Either.swift
+++ b/AppCore/Sources/Models/Either.swift
@@ -7,6 +7,36 @@
 
 import Foundation
 
+/**
+ An enumeration that lets you conditionally bind against a value that is either
+ a type of `Left` or a type of `Right`. Good for holding underlying type infromation
+ in an otherwise erased typed.
+
+ Example usage below for conditional binding in a switch.
+
+ ```
+ public var source: Either<Channel, Mixtape>
+
+ ...
+
+ switch source {
+    case let .left(channel):
+    ...
+    case let .right(mixtape):
+    ...
+ ```
+
+ Or you could use this in an if statement to bind the left or right to gate some logic.
+
+ ```
+ public var source: Either<Channel, Mixtape>
+ ...
+
+ if case let .left(channel) = source {
+    ...
+ }
+ ```
+ */
 public enum Either<Left: Equatable, Right: Equatable>: Equatable {
     case left(Left)
     case right(Right)

--- a/AppCore/Sources/Models/MediaPlayable.swift
+++ b/AppCore/Sources/Models/MediaPlayable.swift
@@ -32,8 +32,9 @@ public struct MediaPlayable: Identifiable, Equatable {
     public var artwork: URL
     public var url: URL
     public var streamURL: URL
+    public var source: Either<Channel, Mixtape>?
 
-    public init(id: String, title: String, subtitle: String? = nil, description: String, artwork: URL, url: URL, streamURL: URL) {
+    public init(id: String, title: String, subtitle: String? = nil, description: String, artwork: URL, url: URL, streamURL: URL, source: Either<Channel, Mixtape>?) {
         self.id = id
         self.title = title
         self.subtitle = subtitle
@@ -41,6 +42,7 @@ public struct MediaPlayable: Identifiable, Equatable {
         self.artwork = artwork
         self.url = url
         self.streamURL = streamURL
+        self.source = source
     }
 }
 
@@ -53,6 +55,7 @@ public extension MediaPlayable {
         artwork = mixtape.media.pictureLarge
         url = mixtape.url ?? URL(string: "https://nts.live")!
         streamURL = mixtape.audioStreamEndpoint
+        source = .right(mixtape)
     }
 
     init(channel: Channel) {
@@ -83,5 +86,7 @@ public extension MediaPlayable {
 
         url = channel.now.details?.url ?? URL(string: "https://nts.live")!
         streamURL = components.url!
+
+        source = .left(channel)
     }
 }

--- a/AppCore/Sources/UserActivityClient/Client.swift
+++ b/AppCore/Sources/UserActivityClient/Client.swift
@@ -81,7 +81,8 @@ public extension NSUserActivity {
                              description: description,
                              artwork: artwork,
                              url: url,
-                             streamURL: streamURL)
+                             streamURL: streamURL,
+                             source: nil)
 
     }
 }

--- a/Marconio.xcodeproj/project.pbxproj
+++ b/Marconio.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		725443AA27B2A4EF00939567 /* AppDelegate_iOS in Frameworks */ = {isa = PBXBuildFile; productRef = 725443A927B2A4EF00939567 /* AppDelegate_iOS */; };
 		7259A9B127BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */; };
 		7259A9B227BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */; };
+		7259A9B427C2CD5E00B66981 /* NowPlayingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */; };
+		7259A9B527C2CD5E00B66981 /* NowPlayingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */; };
 		725B5DF527A44BE900459EE3 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B5DF427A44BE900459EE3 /* DetailView.swift */; };
 		725B5DF627A44BE900459EE3 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B5DF427A44BE900459EE3 /* DetailView.swift */; };
 		727AD85127A6D75100F224CF /* MarconioCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727AD85027A6D75100F224CF /* MarconioCommands.swift */; };
@@ -58,6 +60,7 @@
 		7221DB0527A489F400183057 /* Marconio--iOS--Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Marconio--iOS--Info.plist"; sourceTree = "<group>"; };
 		72276FC827B965E800AD4062 /* FloatingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerView.swift; sourceTree = "<group>"; };
 		7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerOverlayView.swift; sourceTree = "<group>"; };
+		7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingDetailView.swift; sourceTree = "<group>"; };
 		725B5DF427A44BE900459EE3 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		727AD85027A6D75100F224CF /* MarconioCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioCommands.swift; sourceTree = "<group>"; };
 		727AD85327A6D85F00F224CF /* MarconioMacAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioMacAppDelegate.swift; sourceTree = "<group>"; };
@@ -152,6 +155,7 @@
 				72A6B3E727A5FEDE002AF923 /* NowPlayingView.swift */,
 				72276FC827B965E800AD4062 /* FloatingPlayerView.swift */,
 				7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */,
+				7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */,
 			);
 			path = "Now Playing";
 			sourceTree = "<group>";
@@ -389,6 +393,7 @@
 				72F521C727B47BB7001E8239 /* ChannelRow.swift in Sources */,
 				72276FC927B965E800AD4062 /* FloatingPlayerView.swift in Sources */,
 				72E1795627A3AC50009A20ED /* Mixtape+Icons.swift in Sources */,
+				7259A9B427C2CD5E00B66981 /* NowPlayingDetailView.swift in Sources */,
 				72D5928C27A5A21E00D3CE52 /* AppView.swift in Sources */,
 				725B5DF527A44BE900459EE3 /* DetailView.swift in Sources */,
 				72A6B3E827A5FEDE002AF923 /* NowPlayingView.swift in Sources */,
@@ -425,6 +430,7 @@
 				725B5DF627A44BE900459EE3 /* DetailView.swift in Sources */,
 				727AD85E27A6DC8700F224CF /* ChannelsView.swift in Sources */,
 				72A6B3E227A5F42D002AF923 /* DonationView.swift in Sources */,
+				7259A9B527C2CD5E00B66981 /* NowPlayingDetailView.swift in Sources */,
 				72F521C827B47BB7001E8239 /* ChannelRow.swift in Sources */,
 				72A6B3E527A5FD90002AF923 /* URL+Opener.swift in Sources */,
 				727CC0F927A76F0B00CABE53 /* MarconioVersionInformation.swift in Sources */,

--- a/Marconio.xcodeproj/project.pbxproj
+++ b/Marconio.xcodeproj/project.pbxproj
@@ -7,10 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		72276FC927B965E800AD4062 /* FloatingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72276FC827B965E800AD4062 /* FloatingPlayerView.swift */; };
+		72276FCA27B965E800AD4062 /* FloatingPlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72276FC827B965E800AD4062 /* FloatingPlayerView.swift */; };
 		7252EE6527B1682500B8FB83 /* AppCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7252EE6427B1682500B8FB83 /* AppCore */; };
 		7252EE6727B1682F00B8FB83 /* AppCore in Frameworks */ = {isa = PBXBuildFile; productRef = 7252EE6627B1682F00B8FB83 /* AppCore */; };
 		725443A827B2A4E900939567 /* AppDelegate_macOS in Frameworks */ = {isa = PBXBuildFile; productRef = 725443A727B2A4E900939567 /* AppDelegate_macOS */; };
 		725443AA27B2A4EF00939567 /* AppDelegate_iOS in Frameworks */ = {isa = PBXBuildFile; productRef = 725443A927B2A4EF00939567 /* AppDelegate_iOS */; };
+		7259A9B127BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */; };
+		7259A9B227BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */; };
 		725B5DF527A44BE900459EE3 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B5DF427A44BE900459EE3 /* DetailView.swift */; };
 		725B5DF627A44BE900459EE3 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B5DF427A44BE900459EE3 /* DetailView.swift */; };
 		727AD85127A6D75100F224CF /* MarconioCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727AD85027A6D75100F224CF /* MarconioCommands.swift */; };
@@ -52,6 +56,8 @@
 /* Begin PBXFileReference section */
 		721A6E2127AF3613006FF195 /* iOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iOS.entitlements; sourceTree = "<group>"; };
 		7221DB0527A489F400183057 /* Marconio--iOS--Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Marconio--iOS--Info.plist"; sourceTree = "<group>"; };
+		72276FC827B965E800AD4062 /* FloatingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerView.swift; sourceTree = "<group>"; };
+		7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerOverlayView.swift; sourceTree = "<group>"; };
 		725B5DF427A44BE900459EE3 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		727AD85027A6D75100F224CF /* MarconioCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioCommands.swift; sourceTree = "<group>"; };
 		727AD85327A6D85F00F224CF /* MarconioMacAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioMacAppDelegate.swift; sourceTree = "<group>"; };
@@ -144,6 +150,8 @@
 			isa = PBXGroup;
 			children = (
 				72A6B3E727A5FEDE002AF923 /* NowPlayingView.swift */,
+				72276FC827B965E800AD4062 /* FloatingPlayerView.swift */,
+				7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */,
 			);
 			path = "Now Playing";
 			sourceTree = "<group>";
@@ -379,12 +387,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				72F521C727B47BB7001E8239 /* ChannelRow.swift in Sources */,
+				72276FC927B965E800AD4062 /* FloatingPlayerView.swift in Sources */,
 				72E1795627A3AC50009A20ED /* Mixtape+Icons.swift in Sources */,
 				72D5928C27A5A21E00D3CE52 /* AppView.swift in Sources */,
 				725B5DF527A44BE900459EE3 /* DetailView.swift in Sources */,
 				72A6B3E827A5FEDE002AF923 /* NowPlayingView.swift in Sources */,
 				72974A6427AF102A00B33ED8 /* MarconioiOSAppDelegate.swift in Sources */,
 				72F521C527B381CD001E8239 /* ShareSheet.swift in Sources */,
+				7259A9B127BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */,
 				72B2A3E327ACDEB300B539CE /* Marquee.swift in Sources */,
 				72A6B3E127A5F42A002AF923 /* DonationView.swift in Sources */,
 				727AD85127A6D75100F224CF /* MarconioCommands.swift in Sources */,
@@ -399,6 +409,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7259A9B227BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */,
 				727AD85727A6D9EC00F224CF /* NowPlayingView.swift in Sources */,
 				727AD85627A6D86700F224CF /* MarconioMacAppDelegate.swift in Sources */,
 				72C4D07027AEC54A00E85491 /* GeneralSettingsView.swift in Sources */,
@@ -409,6 +420,7 @@
 				72D5928D27A5A21E00D3CE52 /* AppView.swift in Sources */,
 				72C4D07327AEC7C800E85491 /* AboutSettingsView.swift in Sources */,
 				72C4D06D27AE1E9C00E85491 /* SettingsGridView.swift in Sources */,
+				72276FCA27B965E800AD4062 /* FloatingPlayerView.swift in Sources */,
 				72B2A3E427ACDEB300B539CE /* Marquee.swift in Sources */,
 				725B5DF627A44BE900459EE3 /* DetailView.swift in Sources */,
 				727AD85E27A6DC8700F224CF /* ChannelsView.swift in Sources */,

--- a/Marconio.xcodeproj/project.pbxproj
+++ b/Marconio.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7259A9B227BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */; };
 		7259A9B427C2CD5E00B66981 /* NowPlayingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */; };
 		7259A9B527C2CD5E00B66981 /* NowPlayingDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */; };
+		7259A9B727C2E19600B66981 /* NSView+SplitViewFinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7259A9B627C2E19600B66981 /* NSView+SplitViewFinder.swift */; };
 		725B5DF527A44BE900459EE3 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B5DF427A44BE900459EE3 /* DetailView.swift */; };
 		725B5DF627A44BE900459EE3 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725B5DF427A44BE900459EE3 /* DetailView.swift */; };
 		727AD85127A6D75100F224CF /* MarconioCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 727AD85027A6D75100F224CF /* MarconioCommands.swift */; };
@@ -61,6 +62,7 @@
 		72276FC827B965E800AD4062 /* FloatingPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerView.swift; sourceTree = "<group>"; };
 		7259A9B027BE7B7600B66981 /* FloatingPlayerOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingPlayerOverlayView.swift; sourceTree = "<group>"; };
 		7259A9B327C2CD5E00B66981 /* NowPlayingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingDetailView.swift; sourceTree = "<group>"; };
+		7259A9B627C2E19600B66981 /* NSView+SplitViewFinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+SplitViewFinder.swift"; sourceTree = "<group>"; };
 		725B5DF427A44BE900459EE3 /* DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailView.swift; sourceTree = "<group>"; };
 		727AD85027A6D75100F224CF /* MarconioCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioCommands.swift; sourceTree = "<group>"; };
 		727AD85327A6D85F00F224CF /* MarconioMacAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarconioMacAppDelegate.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 				72E1795527A3AC50009A20ED /* Mixtape+Icons.swift */,
 				72A6B3E327A5FCD2002AF923 /* URL+Opener.swift */,
 				72B2A3E227ACDEB300B539CE /* Marquee.swift */,
+				7259A9B627C2E19600B66981 /* NSView+SplitViewFinder.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -415,6 +418,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7259A9B227BE7B7600B66981 /* FloatingPlayerOverlayView.swift in Sources */,
+				7259A9B727C2E19600B66981 /* NSView+SplitViewFinder.swift in Sources */,
 				727AD85727A6D9EC00F224CF /* NowPlayingView.swift in Sources */,
 				727AD85627A6D86700F224CF /* MarconioMacAppDelegate.swift in Sources */,
 				72C4D07027AEC54A00E85491 /* GeneralSettingsView.swift in Sources */,

--- a/Shared/Channels/ChannelsView.swift
+++ b/Shared/Channels/ChannelsView.swift
@@ -74,21 +74,6 @@ struct ChannelsView: View {
         .frame(maxHeight: .infinity)
         .listStyle(.sidebar)
         .navigationTitle("Channels")
-#if os(macOS)
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                Button(action: toggleSidebar, label: {
-                    Label("Sidebar", systemImage: "sidebar.leading")
-                })
-            }
-        }
-#endif
-    }
-
-    private func toggleSidebar() {
-#if os(macOS)
-        NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
-#endif
     }
 
     var isPlayingBack: Bool {

--- a/Shared/Channels/ChannelsView.swift
+++ b/Shared/Channels/ChannelsView.swift
@@ -104,12 +104,7 @@ struct ChannelsView: View {
                     .padding()
                 Spacer()
             }
-        }.background(
-            GeometryReader { proxy in
-                Color.clear
-                    .preference(key: DetailWidthPreferenceKey.self, value: proxy.size.width)
-            }
-        )
+        }
     }
 
     private func contextButton(for playable: MediaPlayable) -> some View {

--- a/Shared/Channels/ChannelsView.swift
+++ b/Shared/Channels/ChannelsView.swift
@@ -35,59 +35,54 @@ struct ChannelsView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            List {
+        List {
 #if os(iOS)
-                // We have to remove the inset set by the List's stlye
-                // otherwise we will have more padding on the left than the right.
-                DonationView()
-                    .listRowInsets(EdgeInsets())
-                    .padding()
+            // We have to remove the inset set by the List's stlye
+            // otherwise we will have more padding on the left than the right.
+            DonationView()
+                .listRowInsets(EdgeInsets())
+                .padding()
 #endif
-                Section("Live") {
-                    ForEach(viewStore.channels) { channel in
-                        let playable = MediaPlayable(channel: channel)
-                        NavigationLink(destination: destination(for: playable)
-                        ) {
-                            ChannelRow(channel: channel)
-                        }
-                        .contextMenu {
-                            contextButton(for: playable)
-                        }
+            Section("Live") {
+                ForEach(viewStore.channels) { channel in
+                    let playable = MediaPlayable(channel: channel)
+                    NavigationLink(destination: destination(for: playable)
+                    ) {
+                        ChannelRow(channel: channel)
+                    }
+                    .contextMenu {
+                        contextButton(for: playable)
                     }
                 }
+            }
 
-                Section("Infinite Mixtapes") {
-                    ForEach(viewStore.mixtapes) { mixtape in
-                        let playable = MediaPlayable(mixtape: mixtape)
-                        NavigationLink(destination: destination(for: playable)) {
-                            Label("\(mixtape.title)", systemImage: mixtape.systemIcon)
-                        }
-                        .contextMenu {
-                            contextButton(for: playable)
-                        }
+            Section("Infinite Mixtapes") {
+                ForEach(viewStore.mixtapes) { mixtape in
+                    let playable = MediaPlayable(mixtape: mixtape)
+                    NavigationLink(destination: destination(for: playable)) {
+                        Label("\(mixtape.title)", systemImage: mixtape.systemIcon)
+                    }
+                    .contextMenu {
+                        contextButton(for: playable)
                     }
                 }
-            }
-            .refreshable {
-                viewStore.send(.loadChannels)
-            }
-            .frame(maxHeight: .infinity)
-            .listStyle(.sidebar)
-            .navigationTitle("Channels")
-#if os(macOS)
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    Button(action: toggleSidebar, label: {
-                        Label("Sidebar", systemImage: "sidebar.leading")
-                    })
-                }
-            }
-#endif
-            if isPlayingBack {
-                nowPlayingView()
             }
         }
+        .refreshable {
+            viewStore.send(.loadChannels)
+        }
+        .frame(maxHeight: .infinity)
+        .listStyle(.sidebar)
+        .navigationTitle("Channels")
+#if os(macOS)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button(action: toggleSidebar, label: {
+                    Label("Sidebar", systemImage: "sidebar.leading")
+                })
+            }
+        }
+#endif
     }
 
     private func toggleSidebar() {
@@ -100,23 +95,21 @@ struct ChannelsView: View {
         return viewStore.playback.playerState != .stopped
     }
 
-    private func nowPlayingView() -> some View {
-        return NowPlayingView(
-            store: store.scope(
-                state: \.playback,
-                action: AppAction.playback
-            )
-        )
-    }
-
     private func destination(for playable: MediaPlayable) -> some View {
+        let scopedStore = store.scope(state: \.playback, action: AppAction.playback)
+
         return ScrollView {
             VStack {
-                DetailView(playable: playable, store: store.scope(state: \.playback, action: AppAction.playback))
+                DetailView(playable: playable, store: scopedStore)
                     .padding()
                 Spacer()
             }
-        }
+        }.background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(key: DetailWidthPreferenceKey.self, value: proxy.size.width)
+            }
+        )
     }
 
     private func contextButton(for playable: MediaPlayable) -> some View {

--- a/Shared/Donation/DonationView.swift
+++ b/Shared/Donation/DonationView.swift
@@ -29,8 +29,19 @@ struct DonationView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
+        }.background(
+            GeometryReader { proxy in
+                background(for: proxy)
+            }
+        )
+#if os(macOS)
+        .frame(width: 350, height: 410)
+#endif
+    }
 
-        }
+    private func background(for proxy: GeometryProxy) -> some View {
+        return Color.clear
+            .preference(key: DetailWidthPreferenceKey.self, value: proxy.size.width)
     }
 
     private func openDonationLink() {

--- a/Shared/Donation/DonationView.swift
+++ b/Shared/Donation/DonationView.swift
@@ -29,19 +29,10 @@ struct DonationView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
-        }.background(
-            GeometryReader { proxy in
-                background(for: proxy)
-            }
-        )
+        }
 #if os(macOS)
         .frame(width: 350, height: 410)
 #endif
-    }
-
-    private func background(for proxy: GeometryProxy) -> some View {
-        return Color.clear
-            .preference(key: DetailWidthPreferenceKey.self, value: proxy.size.width)
     }
 
     private func openDonationLink() {

--- a/Shared/Main/AppView.swift
+++ b/Shared/Main/AppView.swift
@@ -49,8 +49,12 @@ struct AppView: View {
                 )
                 DonationView()
                     .padding()
+            }.toolbar {
+                // HACK: Without this the toolbar will switch between two different types which is very ugly.
+                Spacer()
             }
-        }.onAppear {
+        }
+        .onAppear {
             viewStore.send(.loadInitialData)
         }
     }

--- a/Shared/Main/AppView.swift
+++ b/Shared/Main/AppView.swift
@@ -37,14 +37,18 @@ struct AppView: View {
     }
 
     var body: some View {
-        NavigationView {
-            ChannelsView(store: store)
-            DonationView()
-                .padding()
+        FloatingPlayerOverlayView(store: store) {
+            NavigationView {
+                ChannelsView(store: store)
+                DonationView()
+                    .padding()
+            }
         }.onAppear {
             viewStore.send(.loadInitialData)
         }
     }
+
+
 }
 
 struct AppView_Previews: PreviewProvider {

--- a/Shared/Main/AppView.swift
+++ b/Shared/Main/AppView.swift
@@ -39,7 +39,14 @@ struct AppView: View {
     var body: some View {
         FloatingPlayerOverlayView(store: store) {
             NavigationView {
-                ChannelsView(store: store)
+                ChannelsView(store: store).background(
+                    // Read the width of the channels view that can be used to inset the
+                    // floating mini player by knowning how wide the sidebar is.
+                    GeometryReader { proxy in
+                        Color.clear
+                            .preference(key: SidebarWidthPreferenceKey.self, value: proxy.size.width)
+                    }
+                )
                 DonationView()
                     .padding()
             }

--- a/Shared/Main/MarconioCommands.swift
+++ b/Shared/Main/MarconioCommands.swift
@@ -19,6 +19,5 @@ struct MarconioCommands: Commands {
                 Text("Reload channels…")
             }.keyboardShortcut(.init("r", modifiers: .command))
         }
-        SidebarCommands()
     }
 }

--- a/Shared/MarconioApp.swift
+++ b/Shared/MarconioApp.swift
@@ -26,7 +26,8 @@ struct MarconioApp: App {
                 .onContinueUserActivity(UserActivityClient.Identifiers.playbackActiveIdentifier.rawValue) { activity in
                     appDelegate.viewStore.send(.appDelegate(.continueActivity(activity)))
                 }
-        }.commands {
+        }
+        .commands {
             MarconioCommands(
                 reloadChannels: {
                     appDelegate.viewStore.send(.loadChannels)

--- a/Shared/Now Playing/FloatingPlayerOverlayView.swift
+++ b/Shared/Now Playing/FloatingPlayerOverlayView.swift
@@ -35,7 +35,6 @@ struct FloatingPlayerOverlayView<Content: View>: View {
         }
         #if os(macOS)
         .onPreferenceChange(SidebarWidthPreferenceKey.self) { preferences in
-            print("width is: \(preferences)")
             self.sidebarWidth = preferences
         }
         #endif

--- a/Shared/Now Playing/FloatingPlayerOverlayView.swift
+++ b/Shared/Now Playing/FloatingPlayerOverlayView.swift
@@ -11,7 +11,7 @@ import AppCore
 import LaceKit
 
 struct FloatingPlayerOverlayView<Content: View>: View {
-    @State var detailWidth: CGFloat = 0
+    @State var sidebarWidth: CGFloat = 0
 
     let store: Store<AppState, AppAction>
     let content: Content
@@ -27,16 +27,18 @@ struct FloatingPlayerOverlayView<Content: View>: View {
             VStack {
                 Spacer()
                 HStack(spacing: 0) {
-                    Spacer()
+                    Spacer().frame(width: sidebarWidth)
                     nowPlayingView()
-                        .frame(width: detailWidth)
                         .shadow(color: .black.opacity(0.2), radius: 7, x: 0, y: 0)
-                    Spacer()
                 }
             }
-        }.onPreferenceChange(DetailWidthPreferenceKey.self) { preferences in
-            self.detailWidth = preferences
         }
+        #if os(macOS)
+        .onPreferenceChange(SidebarWidthPreferenceKey.self) { preferences in
+            print("width is: \(preferences)")
+            self.sidebarWidth = preferences
+        }
+        #endif
     }
 
     private func nowPlayingView() -> some View {
@@ -49,7 +51,7 @@ struct FloatingPlayerOverlayView<Content: View>: View {
     }
 }
 
-struct DetailWidthPreferenceKey: PreferenceKey {
+struct SidebarWidthPreferenceKey: PreferenceKey {
     typealias Value = CGFloat
     static var defaultValue: Value = 0
 

--- a/Shared/Now Playing/FloatingPlayerOverlayView.swift
+++ b/Shared/Now Playing/FloatingPlayerOverlayView.swift
@@ -1,0 +1,77 @@
+//
+//  FloatingPlayerOverlayView.swift
+//  Marconio
+//
+//  Created by Brian Michel on 2/17/22.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import AppCore
+import LaceKit
+
+struct FloatingPlayerOverlayView<Content: View>: View {
+    @State var detailWidth: CGFloat = 0
+
+    let store: Store<AppState, AppAction>
+    let content: Content
+
+    init(store: Store<AppState, AppAction>, @ViewBuilder content: () -> Content) {
+        self.store = store
+        self.content = content()
+    }
+
+    var body: some View {
+        ZStack {
+            content
+            VStack {
+                Spacer()
+                HStack(spacing: 0) {
+                    Spacer()
+                    nowPlayingView()
+                        .frame(width: detailWidth)
+                        .shadow(color: .black.opacity(0.2), radius: 7, x: 0, y: 0)
+                    Spacer()
+                }
+            }
+        }.onPreferenceChange(DetailWidthPreferenceKey.self) { preferences in
+            self.detailWidth = preferences
+        }
+    }
+
+    private func nowPlayingView() -> some View {
+        return FloatingPlayerView(
+            store: store.scope(
+                state: \.playback,
+                action: AppAction.playback
+            )
+        )
+    }
+}
+
+struct DetailWidthPreferenceKey: PreferenceKey {
+    typealias Value = CGFloat
+    static var defaultValue: Value = 0
+
+    static func reduce(value: inout Value, nextValue: () -> Value) {
+        value = max(value, nextValue())
+    }
+}
+
+struct FloatingPlayerOverlayView_Previews: PreviewProvider {
+    static let store: Store<AppState, AppAction> = .init(initialState: .init(appDelegateState: .init()),
+                                                         reducer: appReducer,
+                                                         environment: .init(mainQueue: .main,
+                                                                            uuid: UUID.init,
+                                                                            api: LiveAPI(),
+                                                                            appDelegate: .init(),
+                                                                            dbClient: .noop))
+    static var previews: some View {
+        FloatingPlayerOverlayView(store: store) {
+            VStack {
+                Text("Hello World")
+                Button("Press me", action: {})
+            }
+        }
+    }
+}

--- a/Shared/Now Playing/FloatingPlayerOverlayView.swift
+++ b/Shared/Now Playing/FloatingPlayerOverlayView.swift
@@ -29,7 +29,7 @@ struct FloatingPlayerOverlayView<Content: View>: View {
                 HStack(spacing: 0) {
                     Spacer().frame(width: sidebarWidth)
                     nowPlayingView()
-                        .shadow(color: .black.opacity(0.2), radius: 7, x: 0, y: 0)
+                        .shadow(color: .secondary.opacity(0.1), radius: 7, x: 0, y: 0)
                 }
             }
         }

--- a/Shared/Now Playing/FloatingPlayerView.swift
+++ b/Shared/Now Playing/FloatingPlayerView.swift
@@ -15,6 +15,7 @@ struct FloatingPlayerView: View {
     @ObservedObject private var viewStore: ViewStore<PlaybackState, PlaybackAction>
 
     @State var expanded = false
+    @State var showing = false
 
     var canExpand: Bool {
         return viewStore.currentlyPlaying != nil
@@ -47,6 +48,11 @@ struct FloatingPlayerView: View {
                         expanded.toggle()
                     }
                 }
+            }
+            .offset(x: 0, y: showing ? 0 : 500 )
+        }.onChange(of: canExpand) { newValue in
+            withAnimation(.linear(duration: 0.3)) {
+                showing = newValue
             }
         }
     }

--- a/Shared/Now Playing/FloatingPlayerView.swift
+++ b/Shared/Now Playing/FloatingPlayerView.swift
@@ -41,6 +41,7 @@ struct FloatingPlayerView: View {
             }
             .background(.thinMaterial)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).stroke(Color.secondary.opacity(0.2), lineWidth: 1))
             .padding()
             .onTapGesture {
                 if canExpand {
@@ -54,51 +55,6 @@ struct FloatingPlayerView: View {
             withAnimation(.linear(duration: 0.3)) {
                 showing = newValue
             }
-        }
-    }
-}
-
-struct NowPlayingDetailView: View {
-    private let store: Store<PlaybackState, PlaybackAction>
-    @ObservedObject var viewStore: ViewStore<PlaybackState, PlaybackAction>
-
-    init(store: Store<PlaybackState, PlaybackAction>) {
-        self.store = store
-        viewStore = ViewStore(store)
-    }
-
-    var title: String {
-        guard let playable = viewStore.currentlyPlaying else {
-            return "Unknown Sounds"
-        }
-
-        switch playable.source {
-        case .left(_):
-            return "live"
-        case .right(_):
-            return "infinite mixtape"
-        case .none:
-            return "Unknown Sounds"
-        }
-    }
-
-    var body: some View {
-        VStack {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text(title.uppercased()).font(.system(.subheadline, design: .rounded)).foregroundColor(.secondary)
-                        Spacer().frame(height: 7)
-                        Button(action: {}) {
-                            Image(systemName: "ellipsis.circle").font(.system(size: 18))
-                        }
-                        .buttonStyle(.borderless)
-                    }
-                    Spacer().frame(height: 10)
-                    Text(viewStore.currentlyPlaying?.description ?? "Description")
-                }
-            }
-            Divider()
         }
     }
 }

--- a/Shared/Now Playing/FloatingPlayerView.swift
+++ b/Shared/Now Playing/FloatingPlayerView.swift
@@ -1,0 +1,117 @@
+//
+//  FloatingPlayerView.swift
+//  Marconio
+//
+//  Created by Brian Michel on 2/13/22.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import PlaybackCore
+import Models
+
+struct FloatingPlayerView: View {
+    private let store: Store<PlaybackState, PlaybackAction>
+    @ObservedObject private var viewStore: ViewStore<PlaybackState, PlaybackAction>
+
+    @State var expanded = false
+
+    var canExpand: Bool {
+        return viewStore.currentlyPlaying != nil
+    }
+
+    init(store: Store<PlaybackState, PlaybackAction>, expanded: Bool = false) {
+        self.store = store
+        self.expanded = expanded
+        viewStore = ViewStore(store)
+    }
+
+    var body: some View {
+        VStack {
+            Spacer()
+            VStack {
+                if expanded {
+                    NowPlayingDetailView(store: store)
+                        .opacity(expanded ? 1.0 : 0.0)
+                        .scaleEffect(expanded ? 1.0 : 0.3)
+                        .padding([.horizontal, .top])
+                }
+                NowPlayingView(store: store).padding(.horizontal)
+            }
+            .background(.thinMaterial)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .padding()
+            .onTapGesture {
+                if canExpand {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 0.8, blendDuration: 0.6)) {
+                        expanded.toggle()
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct NowPlayingDetailView: View {
+    private let store: Store<PlaybackState, PlaybackAction>
+    @ObservedObject var viewStore: ViewStore<PlaybackState, PlaybackAction>
+
+    init(store: Store<PlaybackState, PlaybackAction>) {
+        self.store = store
+        viewStore = ViewStore(store)
+    }
+
+    var title: String {
+        guard let playable = viewStore.currentlyPlaying else {
+            return "Unknown Sounds"
+        }
+
+        switch playable.source {
+        case .left(_):
+            return "live"
+        case .right(_):
+            return "infinite mixtape"
+        case .none:
+            return "Unknown Sounds"
+        }
+    }
+
+    var body: some View {
+        VStack {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text(title.uppercased()).font(.system(.subheadline, design: .rounded)).foregroundColor(.secondary)
+                        Spacer().frame(height: 7)
+                        Button(action: {}) {
+                            Image(systemName: "ellipsis.circle").font(.system(size: 18))
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                    Spacer().frame(height: 10)
+                    Text(viewStore.currentlyPlaying?.description ?? "Description")
+                }
+            }
+            Divider()
+        }
+    }
+}
+
+struct FloatingPlayerView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            FloatingPlayerView(store: Store(
+                initialState: PlaybackState(),
+                reducer: playbackReducer,
+                environment: PlaybackEnvironment()
+            ))
+
+            FloatingPlayerView(store: Store(
+                initialState: PlaybackState(currentlyPlaying: MediaPlayable(mixtape: .placeholder), playerState: .playing, currentActivity: nil, routePickerView: nil, monitoringRemoteCommands: false),
+                reducer: playbackReducer,
+                environment: PlaybackEnvironment()
+            ),
+                               expanded: true).preferredColorScheme(.light)
+        }
+    }
+}

--- a/Shared/Now Playing/NowPlayingDetailView.swift
+++ b/Shared/Now Playing/NowPlayingDetailView.swift
@@ -14,6 +14,8 @@ struct NowPlayingDetailView: View {
     private let store: Store<PlaybackState, PlaybackAction>
     @ObservedObject var viewStore: ViewStore<PlaybackState, PlaybackAction>
 
+    @State private var shareSheetPresented = false
+
     init(store: Store<PlaybackState, PlaybackAction>) {
         self.store = store
         viewStore = ViewStore(store)
@@ -50,7 +52,14 @@ struct NowPlayingDetailView: View {
                         if let playable = viewStore.currentlyPlaying {
                             Menu {
                                 Section {
+#if os(macOS)
+                                    // Share a string here since macOS is finicky about the specific types of copied items.
                                     SharingMenu(items: [playable.url.absoluteString])
+#else
+                                    Button(action: { shareSheetPresented.toggle() }) {
+                                        Label("Share", systemImage: "square.and.arrow.up")
+                                    }
+#endif
                                     Button(action: {
                                         playable.url.openExternally()
                                     }) {
@@ -63,6 +72,11 @@ struct NowPlayingDetailView: View {
                             .menuStyle(.borderlessButton)
                             .menuIndicator(.hidden)
                             .fixedSize()
+#if os(iOS)
+                            .sheet(isPresented: $shareSheetPresented, onDismiss: nil) {
+                                ShareSheet(items: [playable.url])
+                            }
+#endif
                         }
                     }
                     Spacer().frame(height: 10)

--- a/Shared/Now Playing/NowPlayingDetailView.swift
+++ b/Shared/Now Playing/NowPlayingDetailView.swift
@@ -1,0 +1,98 @@
+//
+//  NowPlayingDetailView.swift
+//  Marconio
+//
+//  Created by Brian Michel on 2/20/22.
+//
+
+import ComposableArchitecture
+import PlaybackCore
+import Models
+import SwiftUI
+
+struct NowPlayingDetailView: View {
+    private let store: Store<PlaybackState, PlaybackAction>
+    @ObservedObject var viewStore: ViewStore<PlaybackState, PlaybackAction>
+
+    init(store: Store<PlaybackState, PlaybackAction>) {
+        self.store = store
+        viewStore = ViewStore(store)
+    }
+
+    var title: String {
+        guard let playable = viewStore.currentlyPlaying else {
+            return "Unknown Sounds"
+        }
+
+        switch playable.source {
+        case .left(_):
+            return "live"
+        case .right(_):
+            return "infinite mixtape"
+        case .none:
+            return "unknown sounds"
+        }
+    }
+
+    var description: String {
+        return viewStore.currentlyPlaying?.description ?? "A description has not been provided."
+    }
+
+    var body: some View {
+        VStack {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text(title.uppercased())
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        if let playable = viewStore.currentlyPlaying {
+                            Menu {
+                                Section {
+                                    SharingMenu(items: [playable.url.absoluteString])
+                                    Button(action: {
+                                        playable.url.openExternally()
+                                    }) {
+                                        Label("Open website", systemImage: "arrow.up.right.square.fill")
+                                    }
+                                }
+                            } label: {
+                                Image(systemName: "ellipsis.circle")
+                            }
+                            .menuStyle(.borderlessButton)
+                            .menuIndicator(.hidden)
+                            .fixedSize()
+                        }
+                    }
+                    Spacer().frame(height: 10)
+                    Text(description)
+                }
+            }
+            Divider()
+        }
+    }
+}
+
+struct NowPlayingDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            NowPlayingDetailView(store: Store(
+                initialState: PlaybackState(currentlyPlaying: MediaPlayable(mixtape: .placeholder)),
+                reducer: playbackReducer,
+                environment: PlaybackEnvironment()
+            ))
+                .frame(width: 400)
+                .preferredColorScheme(.light)
+
+            NowPlayingDetailView(store: Store(
+                initialState: PlaybackState(),
+                reducer: playbackReducer,
+                environment: PlaybackEnvironment()
+            ))
+                .frame(width: 400)
+                .preferredColorScheme(.dark)
+        }
+
+    }
+}

--- a/Shared/Now Playing/NowPlayingView.swift
+++ b/Shared/Now Playing/NowPlayingView.swift
@@ -28,7 +28,6 @@ struct NowPlayingView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Divider()
             Spacer()
             HStack {
                 Button {
@@ -44,7 +43,7 @@ struct NowPlayingView: View {
                     let text = viewStore.currentlyPlaying?.title ?? "Nothing Playing"
                     MarqueeText(
                         text: text,
-                        font: MFont.boldSystemFont(ofSize: 15),
+                        font: MFont.boldSystemFont(ofSize: 16),
                         leftFade: 10,
                         rightFade: 10,
                         startDelay: 10,
@@ -53,7 +52,7 @@ struct NowPlayingView: View {
                     if let subtitle = viewStore.currentlyPlaying?.subtitle {
                         MarqueeText(
                             text: subtitle,
-                            font: MFont.systemFont(ofSize: 12, weight: .light),
+                            font: MFont.systemFont(ofSize: 13, weight: .light),
                             leftFade: 10,
                             rightFade: 10,
                             startDelay: 10,
@@ -65,11 +64,10 @@ struct NowPlayingView: View {
                 if let picker = viewStore.routePickerView {
                     picker.frame(width: C.routeViewWidth)
                 }
-            }.padding(.horizontal)
+            }
             Spacer()
         }
         .frame(height: C.nowPlayingNaturalHeight)
-        .background(.thickMaterial)
     }
 
     var playOrPauseIconImage: String {

--- a/Shared/Utility/NSView+SplitViewFinder.swift
+++ b/Shared/Utility/NSView+SplitViewFinder.swift
@@ -1,0 +1,46 @@
+//
+//  NSView+SplitViewFinder.swift
+//  Marconio (macOS)
+//
+//  Created by Brian Michel on 2/20/22.
+//
+
+import Foundation
+import AppKit
+
+extension NSView {
+    /**
+     Finds the first NSSplitView in the view hierarchy, starting with the view this function is called on.
+     */
+    func findSplitView() -> NSSplitView? {
+        var queue = [NSView]()
+        queue.append(self)
+
+        while !queue.isEmpty {
+            let current = queue.removeFirst()
+            if current is NSSplitView {
+                return current as? NSSplitView
+            }
+            for subview in current.subviews {
+                queue.append(subview)
+            }
+        }
+        return nil
+    }
+
+    /**
+     SwiftUI doesn't allow disabling the split view, so we can attempt to find the first NSSplitViewController
+     and do it ourselves.
+
+     This is a bit of a hack, but seems like par for the course for SwiftUI.
+     */
+    func disableSplitViewCollapsingIfPossible() {
+        guard let splitView = findSplitView(), let controller = splitView.delegate as? NSSplitViewController else {
+            return
+        }
+
+        controller.splitViewItems.first?.canCollapse = false
+        controller.splitViewItems.first?.minimumThickness = 225
+        controller.splitViewItems.first?.maximumThickness = 225
+    }
+}

--- a/macOS/MarconioMacAppDelegate.swift
+++ b/macOS/MarconioMacAppDelegate.swift
@@ -46,6 +46,12 @@ final class MarconioMacAppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         viewStore.send(.appDelegate(.didFinishLaunching))
+
+        // HACK: Disable resizing of the split since that's our desired design.
+        NSApp.windows.first?.contentView?.disableSplitViewCollapsingIfPossible()
+
+        // HACK: Disable the zoom button so you can't expand the app to fill the screen.
+        NSApp.windows.first?.standardWindowButton(NSWindow.ButtonType.zoomButton)?.isEnabled = false
     }
 
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {

--- a/macOS/Sharing/SharingMenu.swift
+++ b/macOS/Sharing/SharingMenu.swift
@@ -33,7 +33,7 @@ struct SharingMenu: View {
                 }
             }
         } label: {
-            Image(systemName: "square.and.arrow.up")
+            Label("Share", systemImage: "square.and.arrow.up")
         }
         .menuIndicator(.hidden)
         .onAppear {


### PR DESCRIPTION
This adds a new floating mini player to iOS and macOS. It lives primarily in the detail screen, but can also expand to show more details about the currently playing audio. This is the next step in the foundation to add SharePlay support now that we have a place where a menu can realistically be produced in order to start a session.